### PR TITLE
Force ERB templates when rendering with helpers.

### DIFF
--- a/lib/sir-trevor/helpers/view_helper.rb
+++ b/lib/sir-trevor/helpers/view_helper.rb
@@ -16,7 +16,7 @@ module SirTrevor
       end
 
       def render_sir_trevor_block(object, image_type = 'large')
-        view_name = "sir-trevor/blocks/#{object['type'].to_s.downcase}_block"
+        view_name = "sir-trevor/blocks/#{object['type'].to_s.downcase}_block.html.erb"
 
         render(view_name,
                :block => object['data'],
@@ -27,7 +27,7 @@ module SirTrevor
         image = pluck_sir_trevor_type(json, "image")
     
         unless image.nil? 
-          render(:partial => "sir-trevor/blocks/image_block", :locals => {:block => image['data'], :image_type => image_type, :protocol => request.protocol}) if image.has_key?("data")
+          render(:partial => "sir-trevor/blocks/image_block.html.erb", :locals => {:block => image['data'], :image_type => image_type, :protocol => request.protocol}) if image.has_key?("data")
         end
       end
       


### PR DESCRIPTION
This pull request hardcodes the file extension when referencing the templates used to render the different content types.

The reason is that this makes possible to render a sir-trevor block even when using different engines, like a JSON view or (in my case) an XML feed written with builder.
