### PR TITLE
Removed Twitter::AutoLink from view_helper so it doesn't pollute rails_autolink.

### DIFF
--- a/lib/sir-trevor/helpers/view_helper.rb
+++ b/lib/sir-trevor/helpers/view_helper.rb
@@ -3,8 +3,7 @@ module SirTrevor
     module ViewHelper
 
       extend ActiveSupport::Concern
-      include Twitter::Autolink
-
+      
       def render_sir_trevor(json, image_type = :large)
         if hash = parse_sir_trevor(json)
           safe_join hash.map { |object|


### PR DESCRIPTION
Breaking change if others have been relying on include Twitter::Autolink from sir-trevor-rails.
