### PR TITLE
Use InstanceTag / TextArea based on Rails version, so that it works in Rails 4

### DIFF
--- a/lib/sir-trevor/helpers/form_helper.rb
+++ b/lib/sir-trevor/helpers/form_helper.rb
@@ -14,11 +14,17 @@ module SirTrevor
         input_html['class'] = "sir-trevor-area visuallyhidden"
         hash = input_html.stringify_keys
 
-        instance_tag = ActionView::Base::InstanceTag.new(object_name, method, self, options.delete(:object))
-        instance_tag.send(:add_default_name_and_id, hash)
-        
         output_buffer = ActiveSupport::SafeBuffer.new
-        output_buffer << instance_tag.to_text_area_tag(input_html)
+        # support both Rails 3 & 4
+	if defined? ActionView::Base::InstanceTag
+          instance_tag = ActionView::Base::InstanceTag.new(object_name, method, self, options.delete(:object))
+          instance_tag.send(:add_default_name_and_id, hash)
+          output_buffer << instance_tag.to_text_area_tag(input_html)
+	else
+	  instance_tag = ActionView::Helpers::Tags::TextArea.new(object_name, method, self, input_html)
+	  instance_tag.send(:add_default_name_and_id, hash)
+	  output_buffer << instance_tag.render
+	end
         
         output_buffer
 


### PR DESCRIPTION
Use InstanceTag for Rails 3 and TextArea otherwise. This allows
sir-trevor-rails to work on Rails 4.

This is based on the fix for the same issue contained within
madebymany/sir-trevor-rails#16

I have redone this so that it will be a cleaner merge
