### PR TITLE
Update view_helper.rb

### DIFF
--- a/lib/sir_trevor_rails/helpers/view_helper.rb
+++ b/lib/sir_trevor_rails/helpers/view_helper.rb
@@ -4,11 +4,11 @@ module SirTrevorRails
       extend ActiveSupport::Concern
 
       def sir_trevor_markdown(text)
-        Redcarpet::Render::HTML.new(hard_wrap: true, filter_html: true,
+        rndr = CustomMarkdownFormatter.new(hard_wrap: true, filter_html: true,
                                     autolink: true, no_intraemphasis: true,
                                     fenced_code: true)
 
-        markdown = Redcarpet::Markdown.new(CustomMarkdownFormatter)
+        markdown = Redcarpet::Markdown.new(rndr)
         markdown.render(text).html_safe
       end
     end


### PR DESCRIPTION
Renderer was using obeying custom formatting, but not RedCarpet options.

Noticed as "hard_wrap" (convert single newlines in paragraphs to <br />) wasn't being applied to formatted text.