### PR TITLE
Allow to pass extra options to sir_trevor_markdown helper

### DIFF
--- a/lib/sir_trevor_rails/helpers/view_helper.rb
+++ b/lib/sir_trevor_rails/helpers/view_helper.rb
@@ -3,10 +3,16 @@ module SirTrevorRails
     module ViewHelper
       extend ActiveSupport::Concern
 
-      def sir_trevor_markdown(text)
-        rndr = CustomMarkdownFormatter.new(hard_wrap: true, filter_html: true,
-                                    autolink: true, no_intraemphasis: true,
-                                    fenced_code: true)
+      DEFAULT_EXTENSIONS = {
+        hard_wrap: true,
+        filter_html: true,
+        autolink: true,
+        no_intraemphasis: true,
+        fenced_code: true
+      }
+
+      def sir_trevor_markdown(text, options = {})
+        rndr = CustomMarkdownFormatter.new(DEFAULT_EXTENSIONS.merge(options))
 
         markdown = Redcarpet::Markdown.new(rndr)
         markdown.render(text).html_safe


### PR DESCRIPTION
For example:

```erb
<div class="st__content-block st__content-block--text">
  <%= sir_trevor_markdown text_block.text, link_attributes: { target: "_blank" } %>
</div>
```