### PR TITLE
Improve block generator

### DIFF
--- a/lib/generators/sir_trevor_rails/block/block_generator.rb
+++ b/lib/generators/sir_trevor_rails/block/block_generator.rb
@@ -11,23 +11,28 @@ module SirTrevorRails
       def create_block
 
         # Copy the JS
-        copy_file "_block.js", "app/assets/javascripts/sir_trevor/blocks/#{name}.js"
-
-        gsub_file "app/assets/javascripts/sir_trevor/blocks/#{name}.js", /SirTrevor\.Blocks\.Example/, "SirTrevor.Blocks.#{name.capitalize}"
-        gsub_file "app/assets/javascripts/sir_trevor/blocks/#{name}.js", /return "Example"/, "return '#{name.capitalize}'"
-        gsub_file "app/assets/javascripts/sir_trevor/blocks/#{name}.js", /type: 'example'/, "type: '#{name.downcase}'"
+        template "_block.js.erb", "app/assets/javascripts/sir_trevor/blocks/#{file_name}.js"
 
         # Copy the HTML
-        copy_file "_block.html.erb", "app/views/sir_trevor/blocks/_#{name}_block.html.erb"
-        gsub_file "app/views/sir_trevor/blocks/_#{name}_block.html.erb", /\s(-block)/, " #{name}-block"
-        gsub_file "app/views/sir_trevor/blocks/_#{name}_block.html.erb", /\s(_block)/, " #{name}_block"
+        template "_block.html.erb", "app/views/sir_trevor/blocks/_#{file_name}_block.html.erb"
 
         # Copy the BlockDecorator
-        copy_file "_block.rb", "app/sir_trevor_blocks/#{name}_block.rb"
-        gsub_file "app/sir_trevor_blocks/#{name}_block.rb", /ExampleBlock/, " #{name}Block"
-
+        template "_block.rb.erb", "app/sir_trevor_blocks/#{file_name}_block.rb"
       end
 
+      private
+
+      def file_name
+        name.underscore
+      end
+
+      def block_name
+        file_name.camelize
+      end
+
+      def css_class
+        file_name.dasherize
+      end
     end
   end
 end

--- a/lib/generators/sir_trevor_rails/block/templates/_block.html.erb
+++ b/lib/generators/sir_trevor_rails/block/templates/_block.html.erb
@@ -1,3 +1,3 @@
-<div class="content-block example-block">
-  <%= example_block %>
+<div class="content-block <%= css_class %>">
+  <%%= <%= file_name %> %>
 </div>

--- a/lib/generators/sir_trevor_rails/block/templates/_block.html.erb
+++ b/lib/generators/sir_trevor_rails/block/templates/_block.html.erb
@@ -1,3 +1,3 @@
-<div class="content-block <%= css_class %>">
-  <%%= <%= file_name %> %>
+<div class="content-block <%= css_class %>-block">
+  <%%= <%= file_name %>_block %>
 </div>

--- a/lib/generators/sir_trevor_rails/block/templates/_block.js.erb
+++ b/lib/generators/sir_trevor_rails/block/templates/_block.js.erb
@@ -4,20 +4,18 @@
   Author: C J Bell @ madebymany
 */
 
-SirTrevor.Blocks.Example = (function(){
-
+SirTrevor.Blocks.<%= block_name %> = (function(){
   return SirTrevor.Block.extend({
-
     // String; Names the block
     // Note – please use underscores when naming
     // Eg example_block should be ExampleBlock
-    type: 'example',
+    type: '<%= file_name %>',
 
     // Function; the title displayed in the toolbar
     // Can return a translated string (if required)
     title: function() {
       // return i18n.t('blocks:example:title');
-      return "Example";
+      return "<%= block_name %>";
     },
 
     // Boolean; show this blockType of the toolbar

--- a/lib/generators/sir_trevor_rails/block/templates/_block.rb
+++ b/lib/generators/sir_trevor_rails/block/templates/_block.rb
@@ -1,2 +1,0 @@
-class ExampleBlock < SirTrevorRails::Block
-end

--- a/lib/generators/sir_trevor_rails/block/templates/_block.rb.erb
+++ b/lib/generators/sir_trevor_rails/block/templates/_block.rb.erb
@@ -1,0 +1,2 @@
+class <%= block_name %>Block < SirTrevorRails::Block
+end


### PR DESCRIPTION
We can use *template* function to replace placeholders
Also name manipulations was changed to keep a compliance with ruby file
and class name pattern.