### PR TITLE
Update SirTrevorRails::ViewResolver to be compatible with Rails 4.2.5.1

### DIFF
--- a/lib/sir_trevor_rails/view_resolver.rb
+++ b/lib/sir_trevor_rails/view_resolver.rb
@@ -5,8 +5,8 @@ module SirTrevorRails
       super("app/views")
     end
 
-    def find_templates(name, prefix, partial, details)
-      super(name, prefix.gsub(/^(.)+(sir_trevor)/, '\2'), partial, details)
+    def find_templates(name, prefix, *args)
+      super(name, prefix.gsub(/^(.)+(sir_trevor)/, '\2'), *args)
     end
 
   end


### PR DESCRIPTION
Rails 4.2.5.1 added a fifth argument to `#find_templates`. Since we don't particularly care what the arguments are, we can just pass them through.