### PR TITLE
Set custom block types

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v0.6.0:
+	date: 2019-02-19
+		- Added custom_block_types to improve block class lookup performance 
+
 v0.4.0:
 	date: 2014-05-20
 	changes:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 v0.6.0:
-	date: 2019-02-19
-		- Added custom_block_types to improve block class lookup performance 
+  date: 2019-02-19
+    - Added custom_block_types to improve block class lookup performance 
 
 v0.4.0:
 	date: 2014-05-20

--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
 # Sir Trevor Rails
 
-A Rails gem for integrating Sir Trevor JS into your Rails 3/4 application.
+A Rails gem for integrating Sir Trevor JS into your Rails 3/4/5 application.
+
+## Upgrade guide to v0.6.0
+
+There is a breaking change which needs to be applied if you've defined custom ruby blocks.
+
+Create an initializer ``config/initializers/sir_trevor_rails.rb``
+
+Add your custom block types in the initializer:
+
+```ruby
+class SirTrevorRails::Block
+  def self.custom_block_types
+    # Type should be string based and prefix of your class name.
+    ["Custom"] # Would relate to CustomBlock
+  end
+end
+```
 
 ## Upgrade guide from v0.4.0-rc.1
 
@@ -73,6 +90,22 @@ Does this content have an image block?
 ```
 
 Return the first video block in the content
+
+## Add custom block types with custom methods
+
+Create an initializer ``config/initializers/sir_trevor_rails.rb``
+
+Add your custom block types in the initializer:
+
+```ruby
+class SirTrevorRails::Block
+  def self.custom_block_types
+    # Type should be string based and prefix of your class name which would be for the following.
+    # TextBlock, HeadingBlock, CustomBlock
+    ["Text", "Heading", "Custom"]
+  end
+end
+```
 
 ## Add custom methods for block content
 

--- a/lib/sir_trevor_rails/block.rb
+++ b/lib/sir_trevor_rails/block.rb
@@ -13,6 +13,11 @@ module SirTrevorRails
       send(:[], :format).present? ? send(:[], :format).to_sym : DEFAULT_FORMAT
     end
 
+    # Sets a list of custom block types to speed up lookup at runtime.
+    def self.custom_block_types
+      []
+    end
+
     def initialize(hash, parent)
       @raw_data = hash
       @parent  = parent
@@ -40,10 +45,15 @@ module SirTrevorRails
     #
     # @param [Symbol] type
     def self.block_class(type)
-      block_name = "#{type.to_s.camelize}Block"
-      begin
-        block_name.constantize
-      rescue NameError
+      type_name = type.to_s.camelize
+      block_name = "#{type_name}Block"
+      if custom_block_types.include?(type_name)
+        begin
+          block_name.constantize
+        rescue NameError
+          block_class!(block_name)
+        end
+      else
         block_class!(block_name)
       end
     end

--- a/sir_trevor_rails.gemspec
+++ b/sir_trevor_rails.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "wrong"
   spec.add_development_dependency "pry-rails"
   spec.add_development_dependency "combustion"
-  spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "sqlite3", "~> 1.3.6"
   spec.add_development_dependency "capybara"
   spec.add_development_dependency "launchy"
 


### PR DESCRIPTION
Improves performance for blocks which are not custom defined.

We no longer rely on `NameError` each time we load a block and only use this approach if the block is known to be custom defined.